### PR TITLE
Bump GitHub Actions, Node and @octokit/rest; add OpenSSL flag to docs build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -36,7 +36,7 @@ jobs:
         run: npm run docs:build
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: ${{ github.ref == 'refs/heads/source' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "My Blog",
   "scripts": {
     "docs:dev": "NODE_OPTIONS=--openssl-legacy-provider vuepress dev docs",
-    "docs:build": "vuepress build docs"
+    "docs:build": "NODE_OPTIONS=--openssl-legacy-provider vuepress build docs"
   },
   "main": "index.js",
   "author": "Laphtes<wenqing4@illinois.edu>",
@@ -15,7 +15,7 @@
     "vuepress": "^1.2.0"
   },
   "dependencies": {
-    "@octokit/rest": "^16.36.0",
+    "@octokit/rest": "^22.0.0",
     "@vuepress/plugin-last-updated": "^1.9.7",
     "@vuepress/plugin-medium-zoom": "^1.9.9",
     "cos-js-sdk-v5": "^0.5.22",


### PR DESCRIPTION
### Motivation
- Modernize CI tool versions and Node runtime to address compatibility and security concerns for the docs build and deployment pipeline.
- Ensure the VuePress build can run under newer Node by adding the legacy OpenSSL flag to prevent crypto-related failures.
- Update the Octokit dependency to a current major to maintain compatibility with GitHub APIs and newer Node versions.

### Description
- Updated GitHub Actions steps to use `actions/checkout@v4`, `actions/setup-node@v4`, and `peaceiris/actions-gh-pages@v4`, and bumped the workflow to use `node-version: 20`.
- Added `NODE_OPTIONS=--openssl-legacy-provider` to the `docs:build` npm script to avoid OpenSSL compatibility issues with VuePress under Node 20.
- Upgraded the `@octokit/rest` dependency from `^16.36.0` to `^22.0.0` in `package.json`.

### Testing
- No automated tests were added or modified in this change and no test job was executed as part of this PR.
- The updated GitHub Actions `deploy` workflow will run automatically on `push` to the `source` branch and on `pull_request` after merging or on CI re-run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9df94d5908327a370988eabd3f6c0)